### PR TITLE
Allow HTTPs in springboot directly 

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -19,3 +19,7 @@ proxy:
       environment:
         - APPLICATION_LOGS_TO_STDOUT=false
   usage-stats-url: http://influxdb:8086/write?db=shinyproxy_usage
+
+server:
+  useForwardHeaders: true
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -49,6 +49,7 @@ http {
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;
+            proxy_set_header   X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
The latest documentation outlines this https://www.shinyproxy.io/security/